### PR TITLE
feat: upgrade CI from Node 12.x (EOL) to Node 20.x LTS

### DIFF
--- a/.github/workflows/master_gifylapse.yml
+++ b/.github/workflows/master_gifylapse.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - name: Set up Node.js version
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-        node-version: '12.x'
+        node-version: '20.x'
 
     - name: npm install, build, and test
       run: |


### PR DESCRIPTION
- Update actions/checkout from @master to @v4
- Update actions/setup-node from @v1 to @v3
- Update node-version from 12.x to 20.x (Active LTS)