### PR TITLE
fix: html housekeeping — lang, meta, favicons, copyright, video fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,16 +1,15 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>GIFYLAPSE | Create Personalized Gifs</title>
-        <meta name="description" content="">
+        <meta name="description" content="Create personalized animated GIFs from your webcam with GifyLapse">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="static/css/styles.css">
         <!-- ========= BOX ICON ========= -->
         <link href='https://unpkg.com/boxicons@2.0.7/css/boxicons.min.css' rel='stylesheet'>
-        <link rel="icon" type="image/png" href="/Users/ahmadabdullahtariq/Documents/Projects/TheDataNoob/images/favicon-32x32.png" sizes="32x32">
-        <link rel="icon" type="image/png" href="/Users/ahmadabdullahtariq/Documents/Projects/TheDataNoob/images/favicon-16x16.png" sizes="16x16">
+
 
     </head>
     <body>
@@ -38,7 +37,7 @@
             <section class="about section " id="about">
                 <div class="about__container bd-grid">
                     <div class="about__img">
-                        <video autoplay="true" id="videoElement"></video>
+                        <video autoplay="true" id="videoElement">Your browser does not support the video element.</video>
                     </div>
                     <div class="about__img">
                         <h1 class="about__subtitle">Cant Find the perfect Gif?</h1>
@@ -79,7 +78,7 @@
             </div>
 
  
-            <p>&#169; 2021 copyright all right reserved</p>
+            <p>&#169; 2026 copyright all right reserved</p>
             </footer>
         <!-- ========= SCROLL REVEAL ========= -->        
         <script src="https://unpkg.com/scrollreveal"></script>


### PR DESCRIPTION
- Add lang="en" to <html> (WCAG 2.1 SC 3.1.1)
- Populate empty meta description
- Remove broken local-path favicon links (/Users/ahmadabdullahtariq/...)
- Update copyright year 2021 → 2026
- Add video fallback text for unsupported browsers