### PR TITLE
fix: surface camera errors in UI and fix jQuery .disabled bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
 
                     <div id="lapse" class="about__img"></div>
                     <div id="result" class="about__img"></div>
+                    <div id="error-message" style="display:none; color:red; padding:8px;"></div>
                 </div>
             </section>
             <!-- ========= Home ========= -->

--- a/public/js/gifylapse.js
+++ b/public/js/gifylapse.js
@@ -16,12 +16,23 @@ if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
         .then(function (stream) {
             video.srcObject = stream;
         })
-        .catch(err => console.log(err));
+        .catch(function(err) {
+            var errorEl = document.getElementById('error-message');
+            errorEl.textContent = 'Camera access denied. Please allow camera permission and refresh.';
+            errorEl.style.display = 'block';
+            document.getElementById('start').disabled = true;
+        });
+} else {
+    var errorEl = document.getElementById('error-message');
+    errorEl.textContent = 'Camera not supported. Please use HTTPS or a modern browser.';
+    errorEl.style.display = 'block';
 }
 
 var timeId;
 document.getElementById('start').addEventListener('click', function () {
-    console.log('startedddddd')
+    var errorEl = document.getElementById('error-message');
+    errorEl.style.display = 'none';
+    errorEl.textContent = '';
     var count = 0;
     timeId = setInterval(function () {
         var div = document.getElementById('lapse');
@@ -36,15 +47,24 @@ document.getElementById('start').addEventListener('click', function () {
         context.drawImage(canvas, 0, 0);
         div.appendChild(canvas);
     }, 2000);
-    $('#start').disabled = true;
-    $('#stop').disabled = false;
+    document.getElementById('start').disabled = true;
+    document.getElementById('stop').disabled = false;
 });
 
 
 document.getElementById('stop').addEventListener('click', function () {
     clearInterval(timeId);
-    console.log('ruk')
     var imgs = document.getElementById('lapse').children;
+
+    if (imgs.length === 0) {
+        var errorEl = document.getElementById('error-message');
+        errorEl.textContent = 'No frames captured. Press GET STARTED and wait before stopping.';
+        errorEl.style.display = 'block';
+        document.getElementById('start').disabled = false;
+        document.getElementById('stop').disabled = true;
+        return;
+    }
+
     var gif = new GIF({ workers: 2, quality: 10 });
 
     for (var i = 0; i < imgs.length; i++) {
@@ -55,16 +75,15 @@ document.getElementById('stop').addEventListener('click', function () {
 
     gif.on('finished', function(blob) {
         var url = URL.createObjectURL(blob)
-        var img = $('<img id="dynamic">'); //Equivalent: $(document.createElement('img'))
+        var img = $('<img id="dynamic">');
         img.attr('id', 'gif');
         img.attr('src', url);
         img.appendTo('#result');
         img.wrap('<a href="' + url+ '" download="gifylapse" />')
-
     });
     gif.render();
-    $('#start').disabled = false;
-    $('#stop').disabled = true;
+    document.getElementById('start').disabled = false;
+    document.getElementById('stop').disabled = true;
 });
 
 


### PR DESCRIPTION
- Add #error-message div to index.html as visible error display target
- Show error when navigator.mediaDevices is unsupported (HTTP/old browser)
- Show error and disable Start on getUserMedia rejection
- Fix jQuery .disabled no-op bug → use document.getElementById().disabled
- Guard gif.render() against zero captured frames with early return