### PR TITLE
feat: add capture settings UI — interval slider, resolution select, f…

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,8 +45,21 @@
                             GifyLapse allows you to create personalized Gifs. For people who actually matter. 
                         </p>       
                         <button id="start" class="button"><i class='bx bx-play-circle'></i> GET STARTED</button>   
-                        <button id="stop"  class="button"><i class='bx bx-pause-circle'></i> STOP</button>  
-                    </div>      
+                        <button id="stop"  class="button"><i class='bx bx-pause-circle'></i> STOP</button>
+                    <div id="settings-panel" style="margin-top:12px;">
+                      <label for="interval-input">Capture interval: <span id="interval-label">2000</span>ms</label><br>
+                      <input type="range" id="interval-input" min="500" max="5000" value="2000" step="500" style="width:200px;" oninput="document.getElementById('interval-label').textContent = this.value">
+                      <br><br>
+                      <label for="resolution-select">Resolution:</label>
+                      <select id="resolution-select">
+                        <option value="320x240">320×240</option>
+                        <option value="640x480" selected>640×480</option>
+                        <option value="1280x720">1280×720</option>
+                      </select>
+                      <br><br>
+                      <span id="frame-count-label" style="display:none;">Frames captured: <span id="frame-count">0</span></span>
+                    </div>
+                    </div>
 
                     <div id="lapse" class="about__img"></div>
                     <div id="result" class="about__img"></div>

--- a/public/js/gifylapse.js
+++ b/public/js/gifylapse.js
@@ -33,22 +33,30 @@ document.getElementById('start').addEventListener('click', function () {
     var errorEl = document.getElementById('error-message');
     errorEl.style.display = 'none';
     errorEl.textContent = '';
-    var count = 0;
+    var interval = parseInt(document.getElementById('interval-input').value, 10);
+    var resParts = document.getElementById('resolution-select').value.split('x');
+    var resWidth = parseInt(resParts[0], 10);
+    var resHeight = parseInt(resParts[1], 10);
+    document.getElementById('frame-count').textContent = '0';
+    document.getElementById('frame-count-label').style.display = 'inline';
     timeId = setInterval(function () {
         var div = document.getElementById('lapse');
         var canvas = document.createElement('canvas');
-        canvas.height = 480;
-        canvas.width = 640;
+        canvas.height = resHeight;
+        canvas.width = resWidth;
         var context = canvas.getContext('2d');
-        context.drawImage(video, 0, 0, 640, 480);
-        context.drawImage(logo_image, 0, 410);
-        context.translate(640, 0);
+        context.drawImage(video, 0, 0, resWidth, resHeight);
+        context.drawImage(logo_image, 0, resHeight - 70);
+        context.translate(resWidth, 0);
         context.scale(-1, 1);
         context.drawImage(canvas, 0, 0);
         div.appendChild(canvas);
-    }, 2000);
+        document.getElementById('frame-count').textContent = String(parseInt(document.getElementById('frame-count').textContent, 10) + 1);
+    }, interval);
     document.getElementById('start').disabled = true;
     document.getElementById('stop').disabled = false;
+    document.getElementById('interval-input').disabled = true;
+    document.getElementById('resolution-select').disabled = true;
 });
 
 
@@ -62,6 +70,8 @@ document.getElementById('stop').addEventListener('click', function () {
         errorEl.style.display = 'block';
         document.getElementById('start').disabled = false;
         document.getElementById('stop').disabled = true;
+        document.getElementById('interval-input').disabled = false;
+        document.getElementById('resolution-select').disabled = false;
         return;
     }
 
@@ -84,6 +94,8 @@ document.getElementById('stop').addEventListener('click', function () {
     gif.render();
     document.getElementById('start').disabled = false;
     document.getElementById('stop').disabled = true;
+    document.getElementById('interval-input').disabled = false;
+    document.getElementById('resolution-select').disabled = false;
 });
 
 


### PR DESCRIPTION
…rame counter

- Interval range input (500–5000ms, default 2000ms) with live label
- Resolution select (320x240 / 640x480 / 1280x720, default 640x480)
- Live frame counter shown during capture, resets on Start
- Settings controls disable during capture, re-enable on Stop
- Parameterize all hardcoded canvas dimensions, interval, logo Y, and mirror translate