### PR TITLE
feat: add mobile-responsive CSS for narrow screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,107 +1,116 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>GIFYLAPSE | Create Personalized Gifs</title>
-        <meta name="description" content="Create personalized animated GIFs from your webcam with GifyLapse">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="static/css/styles.css">
-        <!-- ========= BOX ICON ========= -->
-        <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>GIFYLAPSE | Create Personalized Gifs</title>
+    <meta name="description" content="Create personalized animated GIFs from your webcam with GifyLapse">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="static/css/styles.css">
+    <!-- ========= BOX ICON ========= -->
+    <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
 
 
-    </head>
-    <body>
-        <!-- ========= HEADER ========= -->
-        <header class="l-header">
-            <nav class="nav bd-grid">
-                <div>
-                    <a href="#" class="nav__logo">GIFYLAPSE</a>
+</head>
+
+<body>
+    <!-- ========= HEADER ========= -->
+    <header class="l-header">
+        <nav class="nav bd-grid">
+            <div>
+                <a href="#" class="nav__logo">GIFYLAPSE</a>
+            </div>
+
+        </nav>
+    </header>
+    <main class="l-main">
+        <!-- ========= About ========= -->
+        <section class="about section " id="about">
+            <div class="about__container bd-grid">
+
+                <!-- LEFT COLUMN -->
+                <div class="about__col-left">
+                    <video autoplay="true" id="videoElement">Your browser does not support the video element.</video>
+                    <div id="render-status">
+                        <progress id="gif-progress" value="0" max="100"></progress>
+                        <span id="render-label">Encoding GIF…</span>
+                    </div>
+                    <div id="lapse" class="about__img"></div>
+
                 </div>
 
-            </nav>
-        </header>
-        <main class="l-main">
-            <!-- ========= About ========= -->
-            <section class="about section " id="about">
-                <div class="about__container bd-grid">
+                <!-- RIGHT COLUMN -->
+                <div class="about__col-right">
 
-                    <!-- LEFT COLUMN -->
-                    <div class="about__col-left">
-                        <video autoplay="true" id="videoElement">Your browser does not support the video element.</video>
-                        <div id="render-status">
-                          <progress id="gif-progress" value="0" max="100"></progress>
-                          <span id="render-label">Encoding GIF…</span>
-                        </div>
-                            <div id="lapse" class="about__img"></div>
-
+                    <!-- Section 1: Intro -->
+                    <div class="about__section">
+                        <h1 class="about__subtitle">Cant Find the perfect Gif?</h1>
+                        <p class="about__text">
+                            GifyLapse lets you create personalized GIFs! right in your browser, no uploads, no servers.
+                            Your camera feed never leaves your device, so it's completely private and secure. It's also
+                            open-source feel free to contribute or report issues on <a href="https://github.com/ahmadabdullah247/gifylapse">GitHub</a>.
+                        </p>
+                        <button id="start" class="button"><i class='bx bx-play-circle'></i> GET STARTED</button>
+                        <button id="stop" class="button"><i class='bx bx-pause-circle'></i> STOP</button>
                     </div>
 
-                    <!-- RIGHT COLUMN -->
-                    <div class="about__col-right">
-
-                        <!-- Section 1: Intro -->
-                        <div class="about__section">
-                            <h1 class="about__subtitle">Cant Find the perfect Gif?</h1>
-                            <p class="about__text">
-                                GifyLapse lets you create personalized GIFs — right in your browser, no uploads, no servers. Your camera feed never leaves your device, so it's completely private and secure. It's also open-source — feel free to contribute or report issues on <a href="https://github.com/ahmadabdullah247/gifylapse">GitHub</a>.
-                            </p>
-                            <button id="start" class="button"><i class='bx bx-play-circle'></i> GET STARTED</button>
-                            <button id="stop"  class="button"><i class='bx bx-pause-circle'></i> STOP</button>
-                        </div>
-
-                        <!-- Section 2: Settings -->
-                        <div class="about__section">
-                            <h2 class="about__section-title">Settings</h2>
-                            <div id="settings-panel">
-                              <div class="settings-row">
+                    <!-- Section 2: Settings -->
+                    <div class="about__section">
+                        <h2 class="about__section-title">Settings</h2>
+                        <div id="settings-panel">
+                            <div class="settings-row">
                                 <label for="interval-input">Interval: <span id="interval-label">1000</span>ms</label>
                                 <input type="range" id="interval-input" min="500" max="5000" value="1000" step="500"
-                                  oninput="document.getElementById('interval-label').textContent = this.value">
-                              </div>
-                              <div class="settings-row">
-                                <label for="max-duration-input">Max Duration: <span id="max-duration-label">5</span>s</label>
+                                    oninput="document.getElementById('interval-label').textContent = this.value">
+                            </div>
+                            <div class="settings-row">
+                                <label for="max-duration-input">Max Duration: <span
+                                        id="max-duration-label">5</span>s</label>
                                 <input type="range" id="max-duration-input" min="1" max="15" value="5" step="1"
-                                  oninput="document.getElementById('max-duration-label').textContent = this.value">
-                              </div>
-                              <div class="settings-row">
+                                    oninput="document.getElementById('max-duration-label').textContent = this.value">
+                            </div>
+                            <div class="settings-row">
                                 <label for="resolution-select">Resolution:</label>
                                 <select id="resolution-select">
-                                  <option value="320x240">320×240</option>
-                                  <option value="640x480" selected>640×480</option>
-                                  <option value="1280x720">1280×720</option>
+                                    <option value="320x240">320×240</option>
+                                    <option value="640x480" selected>640×480</option>
+                                    <option value="1280x720">1280×720</option>
                                 </select>
-                              </div>
-                              <div class="settings-row">
-                                <span id="frame-count-label" style="display:none;">Frames captured: <span id="frame-count">0</span></span>
-                              </div>
+                            </div>
+                            <div class="settings-row">
+                                <span id="frame-count-label" style="display:none;">Frames captured: <span
+                                        id="frame-count">0</span></span>
                             </div>
                         </div>
-
-                        <!-- Section 3: Recent GIFs -->
-                        <div class="about__section">
-                            <h2 class="about__section-title">Recent GIFs</h2>
-                            <div id="result" class="about__img"></div>
-                            <div id="error-message"></div>
-                        </div>
-
                     </div>
-                </div>
-            </section>
-        </main>
 
-        <!-- ========= FOOTER ========= -->        
-        <footer class="footer">
-            <p>&#169; 2026 All Rights Reserved by <a href="https://www.thedatanoob.com" class="footer__link">TheDataNoob</a></p>
-        </footer>
-        <!-- ========= SCROLL REVEAL ========= -->        
-        <script src="https://unpkg.com/scrollreveal"></script>
-        <!-- ========= MAIN JS ========= -->        
-        <script src="static/js/main.js" async defer></script>
-        <script src="https://code.jquery.com/jquery-3.5.1.min.js"   integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="   crossorigin="anonymous"></script>
-        <script src="static/js/gif.js"></script>
-        <script src="static/js/gif.worker.js"></script>
-        <script src="static/js/gifylapse.js"></script>  
-    </body>
+                    <!-- Section 3: Recent GIFs -->
+                    <div class="about__section">
+                        <h2 class="about__section-title">Recent GIFs</h2>
+                        <div id="result" class="about__img"></div>
+                        <div id="error-message"></div>
+                    </div>
+
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- ========= FOOTER ========= -->
+    <footer class="footer">
+        <p>&#169; 2026 All Rights Reserved by <a href="https://www.thedatanoob.com" class="footer__link">TheDataNoob</a>
+        </p>
+    </footer>
+    <!-- ========= SCROLL REVEAL ========= -->
+    <script src="https://unpkg.com/scrollreveal"></script>
+    <!-- ========= MAIN JS ========= -->
+    <script src="static/js/main.js" async defer></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"
+        integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+    <script src="static/js/gif.js"></script>
+    <script src="static/js/gif.worker.js"></script>
+    <script src="static/js/gifylapse.js"></script>
+</body>
+
 </html>

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -326,14 +326,16 @@ img{
 #lapse{
   overflow-y:auto;
   height: 300px;
+  padding-top: 1rem;
 }
 #lapse>canvas{
   height: 70px;
 }
 #result>a>img{
   display:block;
-  padding:0px 5px;
+  margin:0 10px 10px 0;
   float:left;
+  border-radius: .5rem;
 }
 #result{
   overflow-y:hidden;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -57,6 +57,7 @@ body{
   font-family: var(--body-font);
   font-size: var(--normal-font-size);
   color: var(--second-color);
+  padding-bottom: 5.5rem;
 }
 h1,h2,p{
   margin: 0;
@@ -440,5 +441,29 @@ progress::-webkit-progress-value {
 progress::-moz-progress-bar {
   background: var(--first-color);
   border-radius: 4px;
+}
+
+/* ===== MOBILE LAYOUT ===== */
+@media screen and (max-width: 767px){
+  .about__container{
+    grid-template-columns: 100%;
+  }
+  .about__col-left video{
+    width: 100%;
+    max-width: 380px;
+  }
+  .about{
+    margin-top: 1rem;
+  }
+  .about__subtitle{
+    font-size: 1.5rem;
+  }
+  .settings-row label{
+    min-width: auto;
+  }
+  #lapse{
+    height: auto;
+    max-height: 200px;
+  }
 }
 


### PR DESCRIPTION
Add padding-bottom to body to clear fixed footer, and add max-width:767px media query with responsive rules for about section, settings labels, and lapse strip.